### PR TITLE
Fixed JSON in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Plugins can also be dynamically discovered by registering URLs to check with `ha
 
 ```json
 {
-  some_plugin: {
+  "some_plugin": {
     "Name": "dummy",
     "Context": "/hawtio",
     "Scripts": [


### PR DESCRIPTION
JSON needs double quotes for strings (and so for keys).