### PR TITLE
Add new hawtconfig.json property: online.namespaceSelector

### DIFF
--- a/hawtconfig.json
+++ b/hawtconfig.json
@@ -15,5 +15,8 @@
     "copyright": "Trademark and copyright information here",
     "imgSrc": "img/hawtio-logo.svg"
   },
-  "disabledRoutes": []
+  "disabledRoutes": [],
+  "online": {
+    "namespaceSelector": null
+  }
 }

--- a/src/app/config/config-manager.spec.ts
+++ b/src/app/config/config-manager.spec.ts
@@ -84,4 +84,42 @@ describe("ConfigService", function () {
 
   });
 
+  describe("online.namespaceSelector property", function () {
+
+    it("given no namespaceSelector property it should not fail", function () {
+      // given
+      configManager = new Core.ConfigManager({online: null});
+      // then
+      expect(configManager.config.online).toBe(null);
+    });
+
+    it("given a simple label name it should return the value", function () {
+      // given
+      configManager = new Core.ConfigManager({online: {namespaceSelector: { mylabel: "myvalue"} }});
+      // when
+      let value = configManager.config.online.namespaceSelector;
+      // then
+      expect(value.mylabel).toBe('myvalue');
+    });
+
+    it("given a complex label name it should return the value", function () {
+      // given
+      configManager = new Core.ConfigManager({online: {namespaceSelector: { "my.dom.ain/mylabel": "myvalue"} }});
+      // when
+      let value = configManager.config.online.namespaceSelector;
+      // then
+      expect(value['my.dom.ain/mylabel']).toBe('myvalue');
+    });
+
+    it("given an a null value it should retrun null", function () {
+      // given
+      configManager = new Core.ConfigManager({online: {namespaceSelector: { "nullvaluelabel": null} }});
+      // when
+      let value = configManager.config.online.namespaceSelector;
+      // then
+      expect(value['nullvaluelabel']).toBe(null);
+    });
+
+  });
+
 });

--- a/src/app/config/config.ts
+++ b/src/app/config/config.ts
@@ -5,6 +5,7 @@ namespace Core {
     login?: Login;
     about?: About;
     disabledRoutes?: string[];
+    online?: Online;
   }
 
   export interface Branding {
@@ -34,6 +35,14 @@ namespace Core {
   export interface AboutProductInfo {
     name: string;
     value: string;
+  }
+
+  export interface Online {
+    namespaceSelector?: LabelSelector;
+  }
+
+  export interface LabelSelector {
+    [key: string]: string;
   }
 
 }


### PR DESCRIPTION
Required to support filtering namespaces by labels.

Ref ENTESB-14539 and hawtio/hawtio-online#64