### PR TITLE
fix: make preferences accessible on Safari

### DIFF
--- a/src/app/navigation/user-dropdown/user-dropdown.component.ts
+++ b/src/app/navigation/user-dropdown/user-dropdown.component.ts
@@ -28,7 +28,7 @@ namespace Nav {
         <button id="userDropdownMenu" class="pf-c-dropdown__toggle pf-m-plain" ng-click="$ctrl.toggle()"
           ng-blur="$ctrl.close()">{{$ctrl.userName}}</button>
         <ul class="pf-c-dropdown__menu pf-m-align-right" ng-show="$ctrl.isOpen">
-          <li><a class="pf-c-dropdown__menu-item" href="#" ng-focus="$ctrl.onPreferencesClicked()">Preferences</a></li>
+          <li><a class="pf-c-dropdown__menu-item" href="#" ng-mousedown="$ctrl.onPreferencesClicked()">Preferences</a></li>
           <span hawtio-extension name="hawtio-logout"></span>
         </ul>
       </div>


### PR DESCRIPTION
**What type of PR is this?**
Bugfix

**What this PR does / why we need it:**
When using Safari, the preferences link does not work. Using _mousedown_ event instead of _focus_ event should allow for better browser compatibility. 

**Which issue(s) this PR fixes:**
#56  
