### PR TITLE
[CVE-2022-0613][CVE-2022-24723] Upgrade urijs to 1.19.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "lodash": "~4.17.21",
     "marked": "0.6.1",
     "typescript": "^3.0.3",
-    "urijs": "1.19.0"
+    "urijs": "1.19.9"
   },
   "devDependencies": {
     "@hawtio/node-backend": "~3.0.0",


### PR DESCRIPTION
https://nvd.nist.gov/vuln/detail/CVE-2022-0613
https://nvd.nist.gov/vuln/detail/CVE-2022-24723